### PR TITLE
Remove DEBIAN_FRONTEND & move apt-get to one-line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # Base system is the LTS version of Ubuntu.
 FROM   ubuntu:14.04
 
-# Make sure we don't get notifications we can't answer during building.
-ENV    DEBIAN_FRONTEND noninteractive
-
 # Download and install everything from the repos.
-RUN    apt-get --yes update; apt-get --yes upgrade
-RUN    apt-get --yes install curl
+RUN    DEBIAN_FRONTEND=noninteractive \
+        apt-get -y update && \
+        apt-get -y upgrade && \
+        apt-get install --no-install-recommends -y \
+            curl
 
 # Download and install TeamSpeak 3
 RUN    curl "http://dl.4players.de/ts/releases/3.0.11.3/teamspeak3-server_linux-amd64-3.0.11.3.tar.gz" -o teamspeak3-server_linux-amd64-3.0.11.3.tar.gz


### PR DESCRIPTION
The ENV for DEBIAN_FRONTEND persists through the build. This causes issues if you ever need to connect to the running instance. 
Also the apt-get should be a one liner to help with maintain ability issues (ensuring that when curl is installed its the most up to date)