### PR TITLE
Update teamspeak version, run a unprivileged user with working logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,21 @@
 # -----------------------------------------------------------------------------
 
 # Base system is Ubuntu 15.10
-FROM   ubuntu:15.10
+FROM   ubuntu:16.04
 
 # Set the Teamspeak version to download
-ENV tsv=3.0.11.4
+ENV TSV=3.0.12.3
 
 # Download and install everything from the repos.
 RUN    DEBIAN_FRONTEND=noninteractive \
         apt-get -y update && \
-        apt-get -y upgrade
+        apt-get -y install bzip2
 
 # Download and install TeamSpeak 3
-ADD    http://dl.4players.de/ts/releases/${tsv}/teamspeak3-server_linux-amd64-${tsv}.tar.gz ./
-RUN    tar zxf teamspeak3-server_linux-amd64-${tsv}.tar.gz; mv teamspeak3-server_linux-amd64 /opt/teamspeak; rm teamspeak3-server_linux-amd64-${tsv}.tar.gz
+ADD    http://dl.4players.de/ts/releases/${TSV}/teamspeak3-server_linux_amd64-${TSV}.tar.bz2 ./
+RUN    tar jxf teamspeak3-server_linux_amd64-$TSV.tar.bz2 && \
+       mv teamspeak3-server_linux_amd64 /opt/teamspeak && \
+       rm teamspeak3-server_linux_amd64-$TSV.tar.bz2
 
 #Add user
 RUN useradd -s /bin/bash teamspeak

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # Require: Docker (http://www.docker.io/)
 # -----------------------------------------------------------------------------
 
-# Base system is Ubuntu 15.10
+# Base system is Ubuntu 16.04
 FROM   ubuntu:16.04
 
 # Set the Teamspeak version to download

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ EXPOSE 9987/udp
 EXPOSE 30033
 EXPOSE 10011
 
+RUN     mkdir /data && chown teamspeak:teamspeak /data
 VOLUME ["/data"]
-USER	teamspeak
+
+USER   teamspeak
 CMD    ["/start"]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,27 @@ name which is `overshard/teamspeak:latest`.
     sudo docker start <container_id>
     sudo docker stop <container_id>
 
+## File Permissions
+
+Docker has no way to change file permissions at runtime without being root. Because of that you have to make sure every file you want the container to use (database or previous logs) is owned by uid and gid 1000.   
+Run `chown 1000:1000 <filename(s)>` on every file or alternatively `chown -R 1000:1000 <data diretory>`   
+
+## docker-compose
+
+You can use docker-compose to simplify the process of building and running.   
+If you do not wish to import an existing database or logfiles just run:
+
+    sudo docker-compose up
+This will build and run the container.   
+If you want to import existing logs or a database read `File Permissions` first.
 
 ## Server Admin Token
 
 You can find the server admin token in /mnt/teamspeak/logs/, search the log
 files for ServerAdmin privilege key created and use that token on first connect.
+
+Alternatively you can run `docker logs <container_id>` which will display    
+the logfile.
 
 
 ### Notes on the run command

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ name which is `overshard/teamspeak:latest`.
 ## File Permissions
 
 Docker has no way to change file permissions at runtime without being root. Because of that you have to make sure every file you want the container to use (database or previous logs) is owned by uid and gid 1000.   
-Run `chown 1000:1000 <filename(s)>` on every file or alternatively `chown -R 1000:1000 <data diretory>`   
+Run `chown 1000:1000 <filename(s)>` on every file or Run `chown -R 1000:1000 /mnt/teamspeak` to fix all permissions recursively.   
 
 ## docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
           - "30033:30033"
           - "10011:10011"
         volumes:
-            - teamspeak-data:/data
+            - teamspeak-data:/data:Z
         restart: always
 volumes:
     teamspeak-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
-server:
-  build: .
-  command: /start
-  ports:
-   - "9987:9987/udp"
-   - "30033:30033"
-   - "127.0.0.1:10011:10011"
-  volumes:
-   - "/mnt/teamspeak:/data"
-  restart: always
+version: '2'
+services:
+    teamspeak:
+        build: .
+        command: /start
+        ports:
+          - "9987:9987/udp"
+          - "30033:30033"
+          - "10011:10011"
+        volumes:
+            - teamspeak-data:/data
+        restart: always
+volumes:
+    teamspeak-data:
+        driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,5 @@ services:
           - "30033:30033"
           - "10011:10011"
         volumes:
-            - teamspeak-data:/data:Z
+            - /mnt/teamspeak:/data:Z
         restart: always
-volumes:
-    teamspeak-data:
-        driver: local

--- a/scripts/start
+++ b/scripts/start
@@ -29,5 +29,4 @@ fi
 # Run the teamspeak server
 export LD_LIBRARY_PATH=/opt/teamspeak
 cd /opt/teamspeak
-./ts3server_linux_amd64 logpath=/data/logs/
-
+./ts3server logpath=/data/logs/

--- a/scripts/start
+++ b/scripts/start
@@ -25,8 +25,7 @@ then
     ln -s /data/ts3server.sqlitedb /opt/teamspeak/ts3server.sqlitedb
 fi
 
-
 # Run the teamspeak server
 export LD_LIBRARY_PATH=/opt/teamspeak
 cd /opt/teamspeak
-./ts3server logpath=/data/logs/
+./ts3server logpath=/data/logs


### PR DESCRIPTION
Hi,
This should fix the logging as unprivileged user as long as people read the section about `File Permissions`  that I added to the README . I also updated the docker-compose.yml to use version 2 (requires docker 1.10 or higher).  
Please take a look at i.t 