### PR TITLE
Update to 3.0.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 FROM   ubuntu:16.04
 
 # Set the Teamspeak version to download
-ENV TSV=3.0.12.3
+ENV TSV=3.0.13.2
 
 # Download and install everything from the repos.
 RUN    DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Change to Version 3.0.13.2
Changelog:

=== Server Release 3.0.13.2  15 august 2016
 - fixed a crash introduced in 3.0.13.1
 - fixed a deadlock in the server causing some instances to hang / be unresponsive
 - fixed a crash reported by a customer.